### PR TITLE
Fix byte-compile warnings about unknown functions

### DIFF
--- a/turbo-log.el
+++ b/turbo-log.el
@@ -27,6 +27,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+
 (defvar turbo-log--prefix "TCL: "
   "Prefix string for every log messages.")
 


### PR DESCRIPTION
```
turbo-log.el:353:1:Warning: the following functions are not known to be defined:
    string-trim-left, string-trim
```